### PR TITLE
chore: change cron schedule to every 10 minutes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # every 15 mins
-    - cron:  '0/15 * * * *'
+    # every 10 mins
+    - cron:  '0/10 * * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
Updated cron schedule to run every 10 minutes instead of 15.

We need to be faster reacting to incidents.